### PR TITLE
Twinkling stars are not used by the StarsScript

### DIFF
--- a/app/unity/Assets/Prefab.meta
+++ b/app/unity/Assets/Prefab.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: bb2877cc1192a4c3a9292a66487b72f8
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/app/unity/Assets/Scenes/Main.unity
+++ b/app/unity/Assets/Scenes/Main.unity
@@ -3575,6 +3575,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1494370636}
+  - component: {fileID: 1494370637}
   m_Layer: 0
   m_Name: Background
   m_TagString: Untagged
@@ -3598,6 +3599,26 @@ Transform:
   - {fileID: 8851420953244891452}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1494370637
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1494370635}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: efb7536268eec704e9fee4c9245b7844, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  background: {fileID: 1494370635}
+  starPrefabs:
+  - {fileID: 3495646869888221308, guid: 2b01d993b164c78258ace0eb6f65303d, type: 3}
+  seed: -1
+  maxStarsPerSector: 15
+  smallStarsPercentage: 95
+  mediumStarsPercentage: 4
+  largeStarsPercentage: 1
 --- !u!1 &1600137064
 GameObject:
   m_ObjectHideFlags: 0
@@ -4140,7 +4161,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1971659375}
   - component: {fileID: 1971659376}
-  - component: {fileID: 1971659377}
   m_Layer: 0
   m_Name: GameController
   m_TagString: Untagged
@@ -4188,26 +4208,6 @@ MonoBehaviour:
     gameObject: {fileID: 1665810259}
   - state: 7
     gameObject: {fileID: 1665810259}
-  StarsScript: {fileID: 0}
---- !u!114 &1971659377
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1971659374}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: efb7536268eec704e9fee4c9245b7844, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  background: {fileID: 1494370635}
-  starPrefabs:
-  - {fileID: 1528787167357437625, guid: 029cb406bac7993489a79fb4a479db19, type: 3}
-  - {fileID: 3109211933398217268, guid: e226c4eb79d01db4cb4a92b0b4f8f349, type: 3}
-  - {fileID: 7394351171565650475, guid: 597d6044183759d47bf063c4f4e7cd1d, type: 3}
-  seed: -1
-  maxStarsPerSector: 10
 --- !u!1 &1994547350
 GameObject:
   m_ObjectHideFlags: 0

--- a/app/unity/Assets/Scenes/SampleScene.unity.meta
+++ b/app/unity/Assets/Scenes/SampleScene.unity.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2cda990e2423bbf4892e6590ba056729
+guid: 3f8d012f2d2fa4840a7719578e5c5002
 DefaultImporter:
   externalObjects: {}
   userData: 

--- a/app/unity/Assets/Scripts/GameScript.cs
+++ b/app/unity/Assets/Scripts/GameScript.cs
@@ -46,13 +46,6 @@ public class GameScript : MonoBehaviour
     public List<TransitionScreen> TransitionScreens = new List<TransitionScreen>();
 
     /// <summary>
-    /// Script that randomly places stars in the background.
-    /// </summary>
-    [SerializeField]
-    public StarsScript StarsScript;
-
-
-    /// <summary>
     /// The previous State the game was in
     /// </summary>
     GameState LastGameState;

--- a/app/unity/Assets/Scripts/StarColor.cs
+++ b/app/unity/Assets/Scripts/StarColor.cs
@@ -36,4 +36,13 @@ public class StarColor : MonoBehaviour
             _dimStar.GetComponent<SpriteRenderer>().color = starColor;
         }
     }
+
+    /// <summary>
+    /// Update star color explicitly/programmatically.
+    /// </summary>
+    public void UpdateStarColor(Color color)
+    {
+        starColor = color;
+        OnValidate();
+    }
 }


### PR DESCRIPTION
- `StarsScript` moved from `GameController` to `Background`. Seems more appropriate.
- `StarColor` script has a new public function to be able to dynamically change the color (for programmatic access).
- `StarsScript` adjusted to:
   - Use Twinkling star prefab instead of static star prefabs (still keeping the List definition for now)
   - Added config to split stars into 3 categories: Large (twinkling), Medium (twinkling), Small (not twinkling, static size)
   - Majority is small sized. Current percentage distribution is 95% 4% 1%. Values are configurable.
   - Added an array of possible realistic HEX color codes to be used for star colors. (Source in the code comments)
   - Twinkling amplitude and frequency are randomized around default values.