### PR TITLE
Fate controllers added to change FATEs color based on decisions made.

### DIFF
--- a/app/unity/Assets/Scenes/ForestPuzzle.unity
+++ b/app/unity/Assets/Scenes/ForestPuzzle.unity
@@ -380,6 +380,7 @@ GameObject:
   m_Component:
   - component: {fileID: 182890579}
   - component: {fileID: 182890580}
+  - component: {fileID: 182890581}
   m_Layer: 0
   m_Name: FATE
   m_TagString: Untagged
@@ -454,6 +455,22 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!114 &182890581
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 182890578}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: acf0798b4e250634cb28b7e82a92bdaa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fateSprite: {fileID: 182890580}
+  lumberjacksLeaver: {fileID: 935507674}
+  activistsLeaver: {fileID: 478163551}
+  player: {fileID: 149196886}
 --- !u!1001 &324490648
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/app/unity/Assets/Scenes/Main.unity
+++ b/app/unity/Assets/Scenes/Main.unity
@@ -439,6 +439,7 @@ GameObject:
   - component: {fileID: 180403365}
   - component: {fileID: 180403367}
   - component: {fileID: 180403366}
+  - component: {fileID: 180403368}
   m_Layer: 5
   m_Name: FATE
   m_TagString: Untagged
@@ -503,6 +504,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 180403364}
   m_CullTransparentMesh: 1
+--- !u!114 &180403368
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 180403364}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4efc67ed96512041b0699044e4f6578, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &238944151
 GameObject:
   m_ObjectHideFlags: 0
@@ -1646,6 +1659,7 @@ GameObject:
   - component: {fileID: 505232231}
   - component: {fileID: 505232233}
   - component: {fileID: 505232232}
+  - component: {fileID: 505232234}
   m_Layer: 5
   m_Name: FATE
   m_TagString: Untagged
@@ -1710,6 +1724,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 505232230}
   m_CullTransparentMesh: 1
+--- !u!114 &505232234
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 505232230}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4efc67ed96512041b0699044e4f6578, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &519420028
 GameObject:
   m_ObjectHideFlags: 0
@@ -3439,6 +3465,7 @@ GameObject:
   - component: {fileID: 934210993}
   - component: {fileID: 934210995}
   - component: {fileID: 934210994}
+  - component: {fileID: 934210996}
   m_Layer: 5
   m_Name: FATE
   m_TagString: Untagged
@@ -3503,6 +3530,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 934210992}
   m_CullTransparentMesh: 1
+--- !u!114 &934210996
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 934210992}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4efc67ed96512041b0699044e4f6578, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &936282250
 GameObject:
   m_ObjectHideFlags: 0
@@ -3514,6 +3553,7 @@ GameObject:
   - component: {fileID: 936282251}
   - component: {fileID: 936282253}
   - component: {fileID: 936282252}
+  - component: {fileID: 936282254}
   m_Layer: 5
   m_Name: FATE
   m_TagString: Untagged
@@ -3578,6 +3618,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 936282250}
   m_CullTransparentMesh: 1
+--- !u!114 &936282254
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 936282250}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4efc67ed96512041b0699044e4f6578, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &978353016
 GameObject:
   m_ObjectHideFlags: 0
@@ -4215,6 +4267,7 @@ GameObject:
   - component: {fileID: 1340478117}
   - component: {fileID: 1340478119}
   - component: {fileID: 1340478118}
+  - component: {fileID: 1340478120}
   m_Layer: 5
   m_Name: FATE
   m_TagString: Untagged
@@ -4279,6 +4332,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1340478116}
   m_CullTransparentMesh: 1
+--- !u!114 &1340478120
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1340478116}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4efc67ed96512041b0699044e4f6578, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1371677849
 GameObject:
   m_ObjectHideFlags: 0
@@ -5554,6 +5619,7 @@ GameObject:
   - component: {fileID: 1900834326}
   - component: {fileID: 1900834328}
   - component: {fileID: 1900834327}
+  - component: {fileID: 1900834329}
   m_Layer: 5
   m_Name: FATE
   m_TagString: Untagged
@@ -5618,6 +5684,18 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1900834325}
   m_CullTransparentMesh: 1
+--- !u!114 &1900834329
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1900834325}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c4efc67ed96512041b0699044e4f6578, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1912060796
 GameObject:
   m_ObjectHideFlags: 0

--- a/app/unity/Assets/Scripts/FateController.cs
+++ b/app/unity/Assets/Scripts/FateController.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Controls the color of FATEs face depending on choices made.
+/// </summary>
+public class FateController : MonoBehaviour
+{
+    /// <summary>
+    /// Called when the script object is initialized.
+    /// </summary>
+    private void Awake()
+    {
+        if (!PersistentVariables.forestPuzzleChoice.HasValue) return;
+
+        Image fateImage = GetComponent<Image>();
+        fateImage.color = new Color(
+            PersistentVariables.forestPuzzleChoice.Value ? 0f : 1f,
+            PersistentVariables.forestPuzzleChoice.Value ? 1f : 0f,
+            0f,
+            1f);
+    }
+}

--- a/app/unity/Assets/Scripts/FateController.cs.meta
+++ b/app/unity/Assets/Scripts/FateController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4efc67ed96512041b0699044e4f6578
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/app/unity/Assets/Scripts/FatePuzzleController.cs
+++ b/app/unity/Assets/Scripts/FatePuzzleController.cs
@@ -1,0 +1,72 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Controls the FATEs face color depending on players proximity to the ending leavers.
+/// </summary>
+public class FatePuzzleController : MonoBehaviour
+{
+    /// <summary>
+    /// Reference to FATEs face sprite to change color.
+    /// </summary>
+    public SpriteRenderer fateSprite;
+
+    /// <summary>
+    /// Reference to Lumberjacks leaver to calculate players proximity to leavers.
+    /// </summary>
+    public Transform lumberjacksLeaver;
+
+    /// <summary>
+    /// Reference to Activists leaver to calculate players proximity to leavers.
+    /// </summary>
+    public Transform activistsLeaver;
+
+    /// <summary>
+    /// Reference to Players leaver to calculate players proximity to leavers.
+    /// </summary>
+    public Transform player;
+
+    /// <summary>
+    /// Max value of a color component.
+    /// </summary>
+    private readonly float colorMax = 255f;
+
+    /// <summary>
+    /// Update is called once per frame.
+    /// </summary>
+    void Update()
+    {
+        //Get the positive distance between players position and leavers position
+        float lumberjacksDelta = Math.Abs(lumberjacksLeaver.position.x - player.position.x);
+        float activistsDelta = Math.Abs(activistsLeaver.position.x - player.position.x);
+
+        float fateRed = colorMax; // Can remain max value
+        float fateGreen = colorMax; // Can remain max value
+        float fateBlue; // Always changed
+
+        // The maximum distance a player can have between each leaver.
+        float hundredPercentDistance = (Math.Abs(lumberjacksLeaver.position.x) + Math.Abs(activistsLeaver.position.x)) / 2;
+        if (lumberjacksDelta < activistsDelta)
+        {
+            // If player is closer to Lumberjacks leaver 
+            // Calculate distance between the leaver and player compared to the max distance in percentages.
+            float currentPercentage = lumberjacksDelta * 100 / hundredPercentDistance;
+            //Reduce Blue and Green parts of the color, making FATE more Red.
+            float gbValue = colorMax * currentPercentage / 100;
+            fateBlue = gbValue;
+            fateGreen = gbValue;
+        }
+        else
+        {
+            // If player is closer to Activists leaver 
+            // Calculate distance between the leaver and player compared to the max distance in percentages.
+            float currentPercentage = activistsDelta * 100 / hundredPercentDistance;
+            //Reduce Red and Blue parts of the color, making FATE more Green.
+            float rbValue = colorMax * currentPercentage / 100;
+            fateRed = rbValue;
+            fateBlue = rbValue;
+        }
+        // Adjust FATEs color using Color32 class that is able to work with 0-255 values. Regular Color class expects values between 0.0f and 1.0f
+        fateSprite.color = new Color32((byte)fateRed, (byte)fateGreen, (byte)fateBlue, (byte)colorMax);
+    }
+}

--- a/app/unity/Assets/Scripts/FatePuzzleController.cs.meta
+++ b/app/unity/Assets/Scripts/FatePuzzleController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: acf0798b4e250634cb28b7e82a92bdaa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/app/unity/Assets/Scripts/PersistentVariables.cs
+++ b/app/unity/Assets/Scripts/PersistentVariables.cs
@@ -12,5 +12,5 @@ public static class PersistentVariables
     /// <summary>
     /// Choice taken in the Forest puzzle.
     /// </summary>
-    public static bool forestPuzzleChoice;
+    public static bool? forestPuzzleChoice;
 }

--- a/app/unity/ProjectSettings/EditorSettings.asset
+++ b/app/unity/ProjectSettings/EditorSettings.asset
@@ -24,8 +24,8 @@ EditorSettings:
   m_EnableEditorAsyncCPUTextureLoading: 0
   m_AsyncShaderCompilation: 1
   m_PrefabModeAllowAutoSave: 1
-  m_EnterPlayModeOptionsEnabled: 1
-  m_EnterPlayModeOptions: 1
+  m_EnterPlayModeOptionsEnabled: 0
+  m_EnterPlayModeOptions: 0
   m_GameObjectNamingDigits: 1
   m_GameObjectNamingScheme: 0
   m_AssetNamingUsesSpace: 1


### PR DESCRIPTION
- FatePuzzleController added to control FATEs fate dynamically in the Puzzle scene based on proximity of the player to the leavers.
- FateController added to control FATEs face color in Main scene based on the choice of the puzzle.
- Previously, Domain reload on Unity `Play` was disabled to speed up the `Play` loading. This now resulted in a development-time bug where static variables were not being reset on Unity restarts. While in regular gameplay, exiting the game would reset the variables, during development it would bring confusion.